### PR TITLE
Fixes #27: external module path is changed to scripts directory path

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -4,13 +4,12 @@ pip install sphinx
 pip install recommonmark
 pip install pypandoc
 git clone https://github.com/fossasia/yaydoc.git yaydoctemp
-mkdir temp
-cd temp
-sphinx-quickstart --ext-githubpages -q -v $VERSION -a $AUTHOR -p $PROJECTNAME -t ../yaydoctemp/templates -d html_theme=${DOCTHEME:-alabaster}
+cd yaydoctemp
+sphinx-quickstart --ext-githubpages -q -v $VERSION -a $AUTHOR -p $PROJECTNAME -t templates/ -d html_theme=${DOCTHEME:-alabaster}
 rm index.rst
 cd ..
-cp -a $DOCPATH. temp/
-cd temp
+cp -a $DOCPATH. yaydoctemp/
+cd yaydoctemp
 make html
 git config --global user.name "Bot"
 git config --global user.email "noreply+bot@example.com"
@@ -27,6 +26,5 @@ git add -f .
 git commit -m "[Auto] Update Built Docs ($(date +%Y-%m-%d.%H:%M:%S))"
 git push origin gh-pages
 cd ../../
-rm -rf temp
 rm -rf yaydoctemp
 rm -- "$0"

--- a/scripts/md2rst.py
+++ b/scripts/md2rst.py
@@ -1,6 +1,6 @@
 from sys import platform
 import pypandoc
-
+import os
 
 def download_pandoc():
     """Download pandoc if not already installed"""

--- a/templates/conf.py_t
+++ b/templates/conf.py_t
@@ -235,7 +235,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 {% endif %}
 
 # Adding scripts directory to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.pardir, 'scripts')))
+sys.path.insert(0, os.path.abspath('scripts'))
 
 import mdinclude
 


### PR DESCRIPTION
close #27 i have removed extra temp folder and i'm running `sphinx-quickstart` in temporary `yaydoctemp` so our conf.py runs relative to yaydoc original folder.
@pri22296 @niranjan94 @imujjwal96 please review and give your suggestion.
Thanks 