### PR TITLE
adds a new environment var LOGO to specify path to a logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - Set the following Environment Variables in Travis CI. [Guide](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings)     
 
 | Environment Variable | Description                                       | Default / FORMAT  |
-|:--------------------:| ------------------------------------------------- |:-----------------:|
+|----------------------| ------------------------------------------------- |-------------------|
 | AUTHOR               | Author of the repository.                         | NONE * |
 | DOCPATH              | Path of the documentation.                        | NONE * (eg. `docs/`) |
 | DOCTHEME             | Name of the theme.                                | alabaster ([built-in themes](http://www.sphinx-doc.org/en/stable/theming.html#builtin-themes)) / <i>(Custom themes available in PyPi are also supported)</i>| 
@@ -22,6 +22,7 @@
 | GITURL               | HTTPS URL of the repository (Not SSH).            | https://\<username>:\<token>@github.com/\<organisation or username>/<repname> * |
 | PROJECTNAME          | Name of the Project.                              | NONE * |
 | VERSION              | Version of the Project.                           | NONE * |
+| LOGO                 | An image to be used as logo for the Project.      | path relative to DOCPATH. *example* - <i>To use DOCPATH/images/logo.svg as the logo, set LOGO as images/logo.svg</i>.|
 
 ```
    * : The following environment variables must be specified for yaydoc to work. 

--- a/generate.sh
+++ b/generate.sh
@@ -10,7 +10,7 @@ mkdir yaydoctemp
 cp -a yaydocclone/scripts/ yaydoctemp/
 cp -a yaydocclone/templates/ yaydoctemp/
 cd yaydoctemp
-sphinx-quickstart --ext-githubpages -q -v $VERSION -a $AUTHOR -p $PROJECTNAME -t templates/ -d html_theme=${DOCTHEME:-alabaster} > /dev/null
+sphinx-quickstart --ext-githubpages -q -v $VERSION -a $AUTHOR -p $PROJECTNAME -t templates/ -d html_theme=${DOCTHEME:-alabaster} -d html_logo=${LOGO:-} > /dev/null
 rm index.rst
 cd ..
 cp -a $DOCPATH. yaydoctemp/

--- a/templates/conf.py_t
+++ b/templates/conf.py_t
@@ -108,6 +108,8 @@ todo_include_todos = {{ ext_todo }}
 # a list of builtin themes.
 #
 
+html_logo = '{{ html_logo }}'
+
 {% if html_theme in (['alabaster', 'classic', 'sphinxdoc', 'scrolls',
                      'agogo', 'traditional', 'nature', 'haiku',
                      'pyramid', 'bizstyle'])


### PR DESCRIPTION
Fixes #45 

Here is a screenshot of how the logo will look in the generated site

![screenshot 20](https://cloud.githubusercontent.com/assets/11555869/26502096/181b7e6a-4259-11e7-8398-488bf2492a8c.png)

I have also modified the alignment of the table in the README as centre alignment was difficult to read.