### PR TITLE
setup yaydoc to be self hosted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ before_script:
 
 script:
   - bash tests/generate_test.sh
+  - chmod +x .utility/deploy_docs.sh && .utility/deploy_docs.sh

--- a/.utility/deploy_docs.sh
+++ b/.utility/deploy_docs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    pip install --user virtualenv
+    cp ./generate.sh ./generate_copy.sh
+    chmod +x ./generate_copy.sh
+    ./generate_copy.sh
+fi

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 Add the following content to the `.travis.yml` file in the root directory of your repository.
 
 **If the primary language is Python**
-```yml
+```yaml
 script:
 - wget https://raw.githubusercontent.com/fossasia/yaydoc/master/generate.sh
 - chmod +x ./generate.sh
@@ -41,7 +41,7 @@ script:
 
 **For Languages other than Python**
 
-```yml
+```yaml
 script:
 - pip install --user virtualenv
 - wget https://raw.githubusercontent.com/fossasia/yaydoc/master/generate.sh

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../README.md


### PR DESCRIPTION
Fixes #50 

- Link to generated docs: https://pri22296.github.io/yaydoc/
- `yml` was changed to `yaml` because of #26 
