### PR TITLE
Fixes #81: added ablity to generate document from different input format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | PROJECTNAME          | Name of the Project.                              | NONE * |
 | VERSION              | Version of the Project.                           | NONE * |
 | LOGO                 | An image to be used as logo for the Project.      | path relative to DOCPATH. *example* - <i>To use DOCPATH/images/logo.svg as the logo, set LOGO as images/logo.svg</i>.|
+| MARKDOWN_FLAVOUR     | Input file format flavour. The supported flavors are  `markdown`, `markdown_strict`, `markdown_phpextra`, `markdown_github`, `markdown_mmd`, `commonmark`| markdown_github   |
 
 ```
    * : The following environment variables must be specified for yaydoc to work. 

--- a/scripts/md2rst.py
+++ b/scripts/md2rst.py
@@ -27,7 +27,9 @@ def download_pandoc():
 
 
 def md2rst(text):
+    markdown_flavour = os.environ.get('MARKDOWN_FLAVOUR', 'markdown_github')
     download_pandoc()
-    output = pypandoc.convert_text(text, 'rst', format='md',
-     filters=[os.path.join('scripts', 'filters', 'yml_filter.py')])
+    yml_filter = os.path.join('scripts', 'filters', 'yml_filter.py')
+    output = pypandoc.convert_text(text, 'rst', format=markdown_flavour,
+                                   filters=[yml_filter])
     return output


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
I have added feature to generate document from different input format

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
close #81 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Right now yaydoc generate documentation from markdown. by having this feature we can able to generate documentation from different input format such rst,github markdown ....
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
