### PR TITLE
add clone via github token as fallback to ssh

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -11,7 +11,10 @@
 # $VERSION - Current version of the project.
 
 REPO=`git config remote.origin.url`
-SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
+URL_SPLIT=(${REPO//// })
+
+USERNAME=${URL_SPLIT[2]}
+REPONAME=(${URL_SPLIT[3]//./ })
 
 # Create an isolated Python environment
 virtualenv -q --python=python $HOME/yaydocvenv
@@ -40,11 +43,6 @@ mkdir _themes
 # Install packages required for documentation generation
 pip install -q -r requirements.txt
 
-URL_SPLIT=(${REPO//// })
-AUTHOR=${AUTHOR:-${URL_SPLIT[2]}}
-DEFAULT_NAME=(${URL_SPLIT[3]//./ })
-PROJECTNAME=${PROJECTNAME:-${DEFAULT_NAME}}
-
 # cleanup
 function clean() {
   cd $ROOT_DIR
@@ -54,7 +52,7 @@ function clean() {
 }
 
 # Setting up documentation sources
-sphinx-quickstart --ext-githubpages -q -v "${VERSION:-development}" -a "$AUTHOR" -p "$PROJECTNAME" -t templates/ -d html_theme=${DOCTHEME:-alabaster} -d html_logo=${LOGO:-} > /dev/null
+sphinx-quickstart --ext-githubpages -q -v "${VERSION:-development}" -a "${AUTHOR:-${USERNAME}}" -p "${PROJECTNAME:-${REPONAME}}" -t templates/ -d html_theme=${DOCTHEME:-alabaster} -d html_logo=${LOGO:-} > /dev/null
 if [ $? -ne 0 ]; then
   echo -e "Failed to initialize build process.\n"
   clean

--- a/publish_docs.sh
+++ b/publish_docs.sh
@@ -8,7 +8,15 @@
 git config --global user.name "Yaydoc Bot"
 git config --global user.email "noreply+bot@example.com"
 
-git clone --quiet $SSH_REPO gh-pages
+GIT_SSH_URL=git@github.com:$USERNAME/$REPONAME.git
+
+git clone --quiet $GIT_SSH_URL gh-pages
+if [ $? -ne 0 ]; then
+  echo -e "Cloning using SSH failed. Trying with Github token instead\n"
+  GIT_HTTPS_URL=https://$USERNAME:$OAUTH_TOKEN@github.com/$USERNAME/$REPONAME.git
+  git clone --quiet $GIT_HTTPS_URL gh-pages
+fi
+
 cd gh-pages
 
 # Create gh-pages branch if it doesn't exist


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Earlier ssh setup was necessary to use yaydoc. I have added usage via a github access token if cloning via ssh fails.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #89 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change would help with seeting up login via github on the webUI to enable existing projects without ssh setup to use yaydoc. to use this an environment variable named OAUTH_TOKEN needs to be setup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my test repository.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
