### PR TITLE
Fixes #122 fix global name FileNotFoundError is not defined error

### DIFF
--- a/modules/scripts/config.py
+++ b/modules/scripts/config.py
@@ -4,6 +4,13 @@ import os
 import argparse
 import yaml
 
+# FileNotFoundError is not available on python 2.
+# To handle that case, defining it on NameError
+# source: https://stackoverflow.com/a/21368622/4127836
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
 
 def update_dict(base, head):
     """Recursively merge dicts"""
@@ -26,7 +33,8 @@ def _get_default_config(username, reponame):
                         },
             'build': {'markdown_flavour': 'markdown_github',
                       'logo': '',
-                      'doctheme': 'fossasia',
+                      'doctheme': 'fossasia_theme',
+                      'docpath': 'docs'
                      },
            }
     return conf


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
- Defines FileNotFoundError in python 2
- adds `docs` as default value for DOCPATH

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #122 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
FileNotFoundError is not available on Python2 . To make the code Python 2 and 3 compatible, this change was required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested on my test repository without `.yaydoc.yml`
Build log: https://travis-ci.org/pri22296/testYaydoc2

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
