### PR TITLE
Fixes #138 Allow user to input custom themes in WebUI

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -88,3 +88,11 @@ a {
 .error {
   color: red;
 }
+
+.es-list li[disabled] {
+  background-color: black;
+  color: white;
+  font-size: .7em;
+  opacity: 1;
+  font-weight: 700;
+}

--- a/views/index.jade
+++ b/views/index.jade
@@ -19,6 +19,7 @@ block content
           label.control-label(for='doc_theme') Doc Theme:
           select#doc_theme.form-control(name='doc_theme')
             option(value='fossasia_theme') fossasia_theme
+            option(disabled='') Built-in Themes
             option(value='alabaster') alabaster
             option(value='classic') classic
             option(value='sphinxdoc') sphinxdoc
@@ -29,7 +30,10 @@ block content
             option(value='haiku') haiku
             option(value='pyramid') pyramid
             option(value='bizstyle') bizstyle
-            option(value='') custom
+            option(disabled='') PyPi Custom Themes
+            option(value='editorial_sphinx_theme') editorial_sphinx_theme
+            option(value='sphinx_adc_theme') sphinx_adc_theme
+            option(value='rtcat_sphinx_theme') rtcat_sphinx_theme
         .form-group#buttons
             button.btn.btn-default(type='button' id='btnGenerate') Generate Docs
             .row
@@ -42,3 +46,5 @@ block content
       .logs.pre-scrollable
         h4(style='text-align: center; padding-top: 5px; color: #ffffff') Console Output
         ul#messages
+  script.
+    $('#doc_theme').editableSelect();

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -4,7 +4,9 @@ html
     title= title
     link(rel='stylesheet', href='/stylesheets/style.css')
     link(rel='stylesheet', href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css')
+    link(rel='stylesheet', href='//rawgithub.com/indrimuska/jquery-editable-select/master/dist/jquery-editable-select.min.css')
     script(src='https://code.jquery.com/jquery-1.11.1.js')
     script(src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js')
+    script(src='//rawgithub.com/indrimuska/jquery-editable-select/master/dist/jquery-editable-select.min.js')
   body
     block content


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Using Editable select, a user can now input their custom themes (Themes from PyPi) to generate their documentation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue: #138 

## Screenshots (if appropriate):
![dsfg](https://user-images.githubusercontent.com/8245662/27252078-e8fa47da-5372-11e7-9161-66952a8b1db1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
