### PR TITLE
Fixes #140 Email generated docs and their preview link

### DIFF
--- a/backend/generator.js
+++ b/backend/generator.js
@@ -1,5 +1,6 @@
 var exports = module.exports = {};
 
+var mailer = require('./mailer');
 var uuidV4 = require("uuid/v4");
 var validation = require("../public/scripts/validation.js");
 var spawn = require('child_process').spawn;
@@ -13,7 +14,7 @@ exports.executeScript = function (socket, formData) {
   var gitUrl = formData.gitUrl;
   var docTheme = formData.docTheme;
   var uniqueId = uuidV4();
-  var webUI = "true"
+  var webUI = "true";
 
   var donePercent = 0;
 
@@ -40,7 +41,9 @@ exports.executeScript = function (socket, formData) {
   process.on('exit', function (code) {
     console.log('child process exited with code ' + code);
     if (code === 0) {
-      socket.emit('success', {email: email, uniqueId: uniqueId, gitUrl: gitUrl});
+      var data = { email: email, uniqueId: uniqueId, gitUrl: gitUrl };
+      mailer.sendEmail(data);
+      socket.emit('success', data);
     } else {
       socket.emit('failure', {errorCode: code});
     }

--- a/backend/mailer.js
+++ b/backend/mailer.js
@@ -1,0 +1,45 @@
+var exports = module.exports = {};
+
+var nodemailer = require('nodemailer');
+var sgTransport = require('nodemailer-sendgrid-transport');
+var hostname =require('../routes/index').hostname;
+
+exports.sendEmail = function (data) {
+  var options = {
+    service: 'SendGrid',
+    auth: {
+      api_user: process.env.SENDGRID_USERNAME,
+      api_key: process.env.SENDGRID_PASSWORD
+    }
+  };
+  
+  var client = nodemailer.createTransport(sgTransport(options));
+  
+  var previewURL = 'http://' + hostname + '/preview/' + data.email + '/' + data.uniqueId + '_preview';
+  var downloadURL = 'http://' + hostname + '/download/' + data.email + '/' + data.uniqueId;
+  var deployURL = 'http://' + hostname + '/github?email=' + data.email + '&uniqueId=' + data.uniqueId + '&gitURL=' + data.gitUrl;
+  
+  var textContent = 'Hey! Your documentation generated successfully. Preview it here: ' + previewURL +
+                    '. Download it here: ' + downloadURL + '. Deploy it here: ' + deployURL;
+  var htmlContent = 'Hey!<br />' +
+                    'Your documentation generated successfully.<br />' +
+                    'Preview it <a href="' + previewURL +'" target="_blank">here</a><br />' +
+                    'Download it <a href="' + downloadURL +'" target="_blank">here</a><br />' +
+                    'Deploy it <a href="' + deployURL +'" target="_blank">here</a><br /><br />' +
+                    'Thank you for using Yaydoc!';
+  
+  client.sendMail({
+    from: 'info@yaydoc.com',
+    to: data.email,
+    subject: 'Preview your generated docs - Yaydoc',
+    text: textContent,
+    html: htmlContent
+  }, function (error, info) {
+    if (error) {
+      console.log(error);
+    } else {
+      console.log('Message sent: ' + info.response);
+    }
+  });
+  
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "jade": "~1.11.0",
     "mocha": "^3.4.2",
     "morgan": "~1.8.1",
+    "nodemailer": "^4.0.1",
+    "nodemailer-sendgrid-transport": "^0.2.0",
     "passport": "^0.3.2",
     "passport-github": "^1.1.0",
     "serve-favicon": "~2.4.2",

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,6 +5,7 @@ var crypter = require("../util/crypter.js")
 var validation = require("../public/scripts/validation.js");
 /* GET home page. */
 router.get("/", function(req, res, next) {
+  exports.hostname = req.get('host');
   res.render("index", { title: "Yaydoc" });
 });
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue: #140 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After this feature is implemented, even if a user mistakenly closes the browser window, he or she will be able to access the features of `Preview`, `Download` and `Deploy` without performing the documentation generation again.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/8245662/27383910-940b801e-56aa-11e7-9a65-49bd3d8bb707.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
