### PR TITLE
Fixes #179 replace editorial_sphinx_theme with sphinx_bootstrap_theme

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -32,9 +32,11 @@ block content
             option(value='pyramid') pyramid
             option(value='bizstyle') bizstyle
             option(disabled='') PyPi Custom Themes
-            option(value='editorial_sphinx_theme') editorial_sphinx_theme
+            option(value='sphinx_bootstrap_theme') sphinx_bootstrap_theme
             option(value='sphinx_adc_theme') sphinx_adc_theme
             option(value='rtcat_sphinx_theme') rtcat_sphinx_theme
+            option(value='guzzle_sphinx_theme') guzzle_sphinx_theme
+            option(value='sphinx_rtd_theme') sphinx_rtd_theme
         .form-group
             label.control-label(for='debug') Debug mode
             input#debug(type='checkbox', value='true', name='debug', checked=false)


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
 Replaced `editorial_sphinx_theme` with `sphinx_bootstrap_theme` in the webUI

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #179 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`editorial_sphinx_theme` fails on import even after installing. Thus the build fails.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
