### PR TITLE
Fixes #190 add support for themes with different distribution and package name

### DIFF
--- a/modules/templates/conf.py_t
+++ b/modules/templates/conf.py_t
@@ -34,9 +34,10 @@ sys.path.insert(0, u'{{ module_path }}')
 {% endif -%}
 {% endif %}
 
-from recommonmark.parser import CommonMarkParser
 import os
 import sys
+import pkg_resources
+from recommonmark.parser import CommonMarkParser
 
 # Adding scripts directory to path
 sys.path.insert(0, os.path.abspath('scripts'))
@@ -133,22 +134,30 @@ else:
         # Non-zero exit code
         print("""{0} is not available on pypi. Please ensure the theme can be installed
         using pip.""".format('{{ html_theme }}'), file=sys.stderr)
+        html_theme = 'fossasia_theme'
+        html_theme_path = ['_themes']
     else:
-        import {{ html_theme }}
-
-        def get_path_to_theme():
-            package_path = os.path.dirname({{ html_theme }}.__file__)
-            for root, dirs, files in os.walk(package_path):
-                if 'theme.conf' in files:
-                    return root
-
-        path_to_theme = get_path_to_theme()
-        if path_to_theme is None:
-            print("\n{0} does not appear to be a sphinx theme.".format('{{ html_theme }}'), file=sys.stderr)
-            html_theme = 'alabaster'
+        try:
+            dist = pkg_resources.get_distribution('{{ html_theme }}')
+            dist_path = os.path.join(dist.location, list(dist._get_metadata('top_level.txt'))[0])
+        except (pkg_resources.DistributionNotFound, IndexError):
+            print("\nError with distribution {0}".format('{{ html_theme }}'))
+            html_theme = 'fossasia_theme'
+            html_theme_path = ['_themes']
         else:
-            html_theme = os.path.basename(path_to_theme)
-            html_theme_path = [os.path.abspath(os.path.join(path_to_theme, os.pardir))]
+            theme_path = None
+            for root, dirs, files in os.walk(dist_path):
+                if 'theme.conf' in files:
+                    theme_path = root
+                    break
+
+            if theme_path is None:
+                print("\n{0} does not appear to be a sphinx theme.".format('{{ html_theme }}'), file=sys.stderr)
+                html_theme = 'fossasia_theme'
+                html_theme_path = ['_themes']
+            else:
+                html_theme = os.path.basename(theme_path)
+                html_theme_path = [os.path.abspath(os.path.join(theme_path, os.pardir))]
 {% endif %}
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/views/index.jade
+++ b/views/index.jade
@@ -37,6 +37,8 @@ block content
             option(value='rtcat_sphinx_theme') rtcat_sphinx_theme
             option(value='guzzle_sphinx_theme') guzzle_sphinx_theme
             option(value='sphinx_rtd_theme') sphinx_rtd_theme
+            option(value='Flask-Sphinx-Themes') Flask-Sphinx-Themes
+            option(value='sphinxjp.themes.sphinxjp') sphinxjp.themes.sphinxjp
         .form-group
             label.control-label(for='debug') Debug mode
             input#debug(type='checkbox', value='true', name='debug', checked=false)


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->

- Added 2 new themes to the webUI
  - Flask-Sphinx-Themes
  - sphinxjp.themes.sphinxjp
- Use `pkg_resources` to find package instead of importing and accessing `__file__`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #190 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The earlier method to search a theme was to import the theme and get the location of the `__init__.py` file using the `__file__` attribute of the imported module and then search for `theme.conf` from there. This created several problems such as when package name and distribution name differ and when distribution name contained `.`(python has special rules for importing packages with `.`)  .

The new method uses pkg_resources to read the metadata of the distribution and from there build the path by using joining `dist.location` (which is usually the site-packages dir) and the first entry from `top_level.txt`. 

Overall this should be a more robust solution. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
