### PR TITLE
Fixes #202: disable deploy link if repository is not from github

### DIFF
--- a/backend/mailer.js
+++ b/backend/mailer.js
@@ -4,7 +4,7 @@ var nodemailer = require('nodemailer');
 var sgTransport = require('nodemailer-sendgrid-transport');
 var jade = require('jade');
 var hostname =process.env.HOSTNAME || 'yaydoc.herokuapp.com';
-
+var validation = require('../public/scripts/validation.js');
 exports.sendEmail = function (data) {
   var options = {
     service: 'SendGrid',
@@ -18,10 +18,16 @@ exports.sendEmail = function (data) {
 
   var previewURL = 'http://' + hostname + '/preview/' + data.email + '/' + data.uniqueId + '_preview';
   var downloadURL = 'http://' + hostname + '/download/' + data.email + '/' + data.uniqueId;
-  var deployURL = 'http://' + hostname + '/github?email=' + data.email + '&uniqueId=' + data.uniqueId + '&gitURL=' + data.gitUrl;
+  var deployURL = "";
+  if (validation.isGithubHTTPS(data.gitUrl)) {
+    deployURL = 'http://' + hostname + '/github?email=' + data.email + '&uniqueId=' + data.uniqueId + '&gitURL=' + data.gitUrl;
+  }
 
   var textContent = 'Hey! Your documentation generated successfully. Preview it here: ' + previewURL +
-                    '. Download it here: ' + downloadURL + '. Deploy it here: ' + deployURL;
+                    '. Download it here: ' + downloadURL ;
+  if (deployURL !== "") {
+    textContent += '. Deploy it here: ' + deployURL;
+  }
   var emailTemplate = jade.compileFile(`${__dirname}/../views/template/email.jade`);
   var htmlContent = emailTemplate({
       previewURL: previewURL,

--- a/views/template/email.jade
+++ b/views/template/email.jade
@@ -117,6 +117,7 @@ html(xmlns='http://www.w3.org/1999/xhtml', xmlns:v='urn:schemas-microsoft-com:vm
                             br
                 //if mso | IE
                   td(style='vertical-align:top;width:200px;')
+            if deployURL !== ""
                 .mj-column-per-33.outlook-group-fix(style='vertical-align:top;display:inline-block;direction:ltr;font-size:13px;text-align:left;width:100%;')
                   table(role='presentation', cellpadding='0', cellspacing='0', width='100%', border='0')
                     tbody


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
I hava removed the deploy link if repository not on github
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
clsoe #202 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
now webui can deploy to gh-pages, so if the repository not from github remove the link
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![email](https://user-images.githubusercontent.com/10010900/27752383-4735dba8-5dfe-11e7-922c-61b552b11428.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
