### PR TITLE
Fixes #229 #236 Changed value passed to genindex when DOCPATH is .

### DIFF
--- a/backend/mailer.js
+++ b/backend/mailer.js
@@ -30,7 +30,7 @@ exports.sendEmail = function (data) {
     textContent += '. Deploy to Github Pages: ' + githubDeployURL;
   }
 
-  textContent += '.Deploy to Heroku: ' + herokuDeployURL '.';
+  textContent += '.Deploy to Heroku: ' + herokuDeployURL + '.';
 
   var emailTemplate = jade.compileFile(`${__dirname}/../views/template/email.jade`);
   var htmlContent = emailTemplate({

--- a/modules/templates/conf.py_t
+++ b/modules/templates/conf.py_t
@@ -188,7 +188,6 @@ else:
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['{{ dot }}static']
 
-
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Apart from the mentioned change, also created two functions to easily ignore multiple files and directories when generating toctrees.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #229
Fixes #236 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was needed because if DOCPATH is ".", the auto-generated indx.rst created links to readme like
`../README.md` where it should have been `README.md`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build Log: https://travis-ci.org/pri22296/testYaydoc2/builds/251209983

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
