### PR TITLE
Fixes 253: removing multiple commit on documentation generation using CI

### DIFF
--- a/routes/ci.js
+++ b/routes/ci.js
@@ -78,47 +78,55 @@ router.post('/register', function (req, res, next) {
 })
 
 router.post('/webhook', function(req, res, next) {
-  var event = req.get('X-GitHub-Event')
-  switch (event) {
-    case "push":
-      repositoryModel.findOneRepository(
-        {
-          githubId: req.body.repository.owner.id,
-          name: req.body.repository.name
-        }
-      ).
-      then(function(result) {
-        var data = {
-          email: result.email,
-          gitUrl: req.body.repository.clone_url,
-          docTheme: "",
-        }
-        generator.executeScript({}, data, function(err, generatedData) {
-          if (err) {
-            console.log(err);
-          } else {
-            deploy.deployPages({}, {
-              email: result.email,
-              gitURL: req.body.repository.clone_url,
-              username: result.username,
-              uniqueId: generatedData.uniqueId,
-              encryptedToken: result.accessToken
-            })
+  var event = req.get('X-GitHub-Event');
+  var branch = req.body.ref.split("/")[2];
+  if (branch !== "gh-pages") {
+    switch (event) {
+      case "push":
+        repositoryModel.findOneRepository(
+          {
+            githubId: req.body.repository.owner.id,
+            name: req.body.repository.name
           }
+        ).
+        then(function(result) {
+          var data = {
+            email: result.email,
+            gitUrl: req.body.repository.clone_url,
+            docTheme: "",
+          }
+          generator.executeScript({}, data, function(err, generatedData) {
+            if (err) {
+              console.log(err);
+            } else {
+              deploy.deployPages({}, {
+                email: result.email,
+                gitURL: req.body.repository.clone_url,
+                username: result.username,
+                uniqueId: generatedData.uniqueId,
+                encryptedToken: result.accessToken
+              })
+            }
+          })
         })
-      })
-      .catch((err) => {
-        console.log(err);
-      })
-      res.json({
-        status: true
-      })
-      break;
-    default:
-      res.json({
-        status: false,
-        description: 'undefined event'
-      })
+        .catch((err) => {
+          console.log(err);
+        })
+        res.json({
+          status: true
+        })
+        break;
+      default:
+        res.json({
+          status: false,
+          description: 'undefined event'
+        })
+    }
+  } else {
+    res.json({
+      status: false,
+      description: "invalid branch"
+    })
   }
 })
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Right now documentation is pushed for each webhook request. so when we push to gh-pages also we getting webhook request then ci making one more deploy and it keeps on going so I changed the `webhook` handler to do the generation if any changes in the master branch
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best Practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
