### PR TITLE
Fixes #263: commit watcher is added to track files in every commit

### DIFF
--- a/util/commitWatcher.js
+++ b/util/commitWatcher.js
@@ -1,0 +1,40 @@
+const request = require("request");
+const path = require("path");
+/*
+docChanged: return boolean if any changes happened to specific file format
+@params {string} sha - commit sha value
+@params {string} username - github username
+@params {string} repoName - github repository name
+@params {array} format - array of file extensions
+@return promise on resolve you get boolean
+*/
+
+exports.docChanged = function (sha, username, repoName, formats) {
+  return new Promise(function(resolve, reject) {
+    request({
+      url: `https://api.github.com/repos/${username}/${repoName}/commits/${sha}`,
+      headers: {
+        'User-Agent': 'request'
+      }
+    },
+    function (err, res, body) {
+      if (err) {
+        reject(err)
+      } else {
+        let result = JSON.parse(body);
+        let changedFileExtension = result.files.map(function (x) {
+          return path.extname(x.filename)
+        })
+        for (let i = 0; i < changedFileExtension.length; i++) {
+          if (formats.indexOf(changedFileExtension[i]) >  -1) {
+            resolve(true)
+            break
+          }
+          if (i === changedFileExtension.length - 1) {
+            resolve(false)
+          }
+        }
+      }
+    })
+  })
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
I have used GitHub APIs to check what files has been changed in the last commit and by making use of this I'm generating documentation.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
close #263 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
now documentation is being generated for each on every commit even if there are no changes in documentation files so it wastes resources. by having this feature we able to generate and push documentation only if any changes in the documentation.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
