### PR TITLE
Fixes #270 Handle links to other documents from rst files

### DIFF
--- a/modules/scripts/linkfix.py
+++ b/modules/scripts/linkfix.py
@@ -21,14 +21,13 @@ def is_relative(path):
     """whether `path` is relative"""
     return not bool(urlparse(path).netloc)
 
-def get_html_path(path):
+def get_html_path(path, filetype):
     """
     Returns path with extension html if original extension is md or rst or
-    no extension at all. This method is meant to only be called for modifying
-    markdown links.
+    if filetype is markdown and path has no extension at all.
     """
     basepath, ext = os.path.splitext(path)
-    if ext in ('', '.md', '.rst'):
+    if ext in ('.md', '.rst') or (filetype == 'md' and ext == ''):
         return basepath + '.html'
     return path
 
@@ -56,8 +55,7 @@ def fix_relative_links(content, path):
         link = match_object.group('link').replace(os.path.sep, '/')
 
         if is_relative(link):
-            if filetype == 'md':
-                link = get_html_path(link)
+            link = get_html_path(link, filetype)
             # Split path into tokens ignoring starting and trailing slash
             splitted = [value for value in link.split('/') if value]
             if len(splitted) > level:


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
In `rst` files, although the correct way to refer other documents is to use `:doc:` but that won't work with github AFAIK. Also directly linking to `md` and `rst` files is very common, so convert those links to html when building the site.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #270 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Demo deployment: https://yaydoc272.herokuapp.com/

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
