### PR TITLE
Fixes #294 Allow README to refer to images outside docpath

### DIFF
--- a/modules/templates/conf.py_t
+++ b/modules/templates/conf.py_t
@@ -122,7 +122,6 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = {{ ext_todo }}
 
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/tests/test.py
+++ b/tests/test.py
@@ -75,6 +75,18 @@ class RelativeLinkFixTestCase(unittest.TestCase):
         new_content = linkfix.fix_relative_links(rst_content, source_path)
         self.assertEqual(new_content, '`title     <directory/file>`')
 
+    def test_with_html(self):
+        html_content = '<img src="docs/directory/file">'
+        source_path = os.path.join(os.pardir, 'README.md')
+        new_content = linkfix.fix_relative_links(html_content, source_path)
+        self.assertEqual(new_content, '<img src="directory/file.html">')
+
+    def test_with_image(self):
+        md_content = '![icon](app/src/icons/launcher.png)'
+        source_path = os.path.join(os.pardir, 'README.md')
+        new_content = linkfix.fix_relative_links(md_content, source_path)
+        self.assertEqual(new_content, '![icon](../app/src/icons/launcher.png)')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
- This PR ensures that any images referenced using the image syntax will be properly included in the build although images in embedded html would still need to be inside `doc_path/_static` 
- Added extra tests for images and html links

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #294 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://yaydoc298.herokuapp.com

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
