### PR TITLE
Fixes #314 Leave link unchanged if starts with `#`

### DIFF
--- a/modules/scripts/linkfix.py
+++ b/modules/scripts/linkfix.py
@@ -47,7 +47,7 @@ def is_path_image(path):
 
 
 def fixlink(link, level, linktype, filetype=None):
-    if is_relative(link):
+    if is_relative(link) and not link.startswith('#'):
         splitted = [value for value in get_html_path(link, filetype).split('/')
                     if value]
         if is_path_image(link) and linktype != 'html':

--- a/tests/test.py
+++ b/tests/test.py
@@ -87,6 +87,18 @@ class RelativeLinkFixTestCase(unittest.TestCase):
         new_content = linkfix.fix_relative_links(md_content, source_path)
         self.assertEqual(new_content, '![icon](../app/src/icons/launcher.png)')
 
+    def test_local_markdown_link(self):
+        md_content = '[title](#section)'
+        source_path = os.path.join(os.pardir, 'README.md')
+        new_content = linkfix.fix_relative_links(md_content, source_path)
+        self.assertEqual(new_content, '[title](#section)')
+
+    def test_local_rst_link(self):
+        md_content = '`title<#section>`'
+        source_path = os.path.join(os.pardir, 'README.md')
+        new_content = linkfix.fix_relative_links(md_content, source_path)
+        self.assertEqual(new_content, '`title<#section>`')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
If a link startswith `#`, it would be now left unchanged. No path based modifications and no extension modification would be done

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #314

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment: https://yaydoc314.herokuapp.com/

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
