### PR TITLE
Fixes #332 Add Theme options to yaydoc.yml

### DIFF
--- a/.yaydoc.yml
+++ b/.yaydoc.yml
@@ -5,7 +5,8 @@ metadata:
 
 build:
   source: docs/
-  theme: sphinx_fossasia_theme
+  theme:
+    name: sphinx_fossasia_theme
   github_ribbon:
     color: red
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ metadata:
 
 ```yaml
 build:
-  theme: sphinx_fossasia_theme         # Name of the theme. Apart from built in sphinx themes, custom themes from PyPI are also supported, default: sphinx_fossasia_theme
+  theme:
+    name: sphinx_fossasia_theme        # Name of the theme. Apart from built in sphinx themes, custom themes from PyPI are also supported, default: sphinx_fossasia_theme
+    options:                           # The respective theme options in the form `"<key>=<value>"`. They are theme specific.
+      - "link_about=/about"
+      - "show_fossasia_logo=true"
   source: docs                         # Path of the documentation, default: docs
   logo: images/logo.svg                # Path to an image to be used as logo for the Project. It should be relative to `source`.
   markdown_flavour: markdown_github    # Markdown format flavour. should be one of `markdown`, `markdown_strict`, `markdown_phpextra`, `markdown_github`, `markdown_mmd`, `commonmark`, default: markdown_github

--- a/generate.sh
+++ b/generate.sh
@@ -110,6 +110,7 @@ sphinx-quickstart -q -v "$VERSION" -a "$AUTHOR" -p "$PROJECTNAME" -t templates/ 
   -d html_logo=$LOGO -d root_dir=$ROOT_DIR -d autoapi_python=$AUTOAPI_PYTHON -d mock_modules=$MOCK_MODULES \
   -d owner=$OWNER -d repo=$REPONAME -d github_ribbon_enable=$GITHUB_RIBBON_ENABLE \
   -d github_ribbon_position=$GITHUB_RIBBON_POSITION -d github_ribbon_color=$GITHUB_RIBBON_COLOR \
+  -d theme_opts_keys=$DOCTHEME_OPTIONS_KEYS -d theme_opts_values=$DOCTHEME_OPTIONS_VALUES \
   >>${LOGFILE} 2>>${LOGFILE}
 if [ $? -ne 0 ]; then
   print_danger "Failed to initialize build process.\n"

--- a/modules/templates/conf.py_t
+++ b/modules/templates/conf.py_t
@@ -73,7 +73,8 @@ extensions = ['sphinx.ext.githubpages',
     'javasphinx',
     'sphinxcontrib.apiblueprint',
     'blog',
-    'timeline']
+    'timeline',
+]
 
 {% if github_ribbon_enable == 'true' %}
 extensions.append('sphinxcontrib.github_ribbon')
@@ -195,7 +196,11 @@ else:
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {}
+{% if theme_opts_keys and theme_opts_values %}
+for key, value in zip('{{ theme_opts_keys }}'.split(','), '{{ theme_opts_values }}'.split(',')):
+    html_theme_options[key] = value
+{% endif %}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Added option to specify theme options.

Eg.,
```yaml
build:
  theme:
    name: <name of theme>
    options:
      - "<key1>=<value1>"
      - "<key2>=<value2>"
```

Currently, values are constrained to strings.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #332 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment: https://yaydocx.herokuapp.com

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
