### PR TITLE
Fixes #345 Adds option to show github buttons

### DIFF
--- a/.yaydoc.yml
+++ b/.yaydoc.yml
@@ -7,8 +7,8 @@ build:
   source: docs/
   theme:
     name: sphinx_fossasia_theme
-  github_ribbon:
-    color: red
+  github_button:
+    show_count: true
 
 publish:
   ghpages:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ build:
   github_ribbon:         # Display a `Fork me on Github` ribbon
     position: right      # Position of the ribbon, Allowed values: left | right, default: right
     color: green         # Color of the ribbon, Allowed values: red | green | darkblue | orange | gray | white, default: red
+  github_button:         # Display various Github buttons.
+    buttons:
+      watch: true        # Display watch button, default: true
+      star: true         # Display star button, default: true
+      issues: true       # Display issues button, default: true
+      fork: true         # Display fork button, default: true
+      follow: true       # Display follow button, default: true
+    show_count: true     # Display count beside buttons
+    large: true          # Use large buttons
 ```
 
 - Configuring publishers

--- a/generate.sh
+++ b/generate.sh
@@ -111,6 +111,8 @@ sphinx-quickstart -q -v "$VERSION" -a "$AUTHOR" -p "$PROJECTNAME" -t templates/ 
   -d owner=$OWNER -d repo=$REPONAME -d github_ribbon_enable=$GITHUB_RIBBON_ENABLE \
   -d github_ribbon_position=$GITHUB_RIBBON_POSITION -d github_ribbon_color=$GITHUB_RIBBON_COLOR \
   -d theme_opts_keys=$DOCTHEME_OPTIONS_KEYS -d theme_opts_values=$DOCTHEME_OPTIONS_VALUES \
+  -d github_button_enable=${GITHUB_BUTTON_ENABLE} -d github_buttons=${GITHUB_BUTTONS} \
+  -d github_button_large=${GITHUB_BUTTON_LARGE} -d github_button_show_count=${GITHUB_BUTTON_SHOW_COUNT} \
   >>${LOGFILE} 2>>${LOGFILE}
 if [ $? -ne 0 ]; then
   print_danger "Failed to initialize build process.\n"

--- a/modules/scripts/config.py
+++ b/modules/scripts/config.py
@@ -188,6 +188,15 @@ def get_default_config(owner, repo):
                       'github_ribbon': {'position': 'right',
                                         'color': 'red',
                                        },
+                      'github_button': {'buttons': {'watch': True,
+                                                    'star': True,
+                                                    'fork': True,
+                                                    'issues': True,
+                                                    'follow': True
+                                                   },
+                                        'show_count': True,
+                                        'large': True,
+                                       },
                      },
             'publish': {'ghpages': {'url': None,},
                         'heroku': {'app_name': None,},
@@ -239,6 +248,13 @@ def get_envdict(yaml_config, default_config):
         keys and values for theme options."""
         return [option.split('=')[index].strip() for option in options]
 
+    def github_btn_callback(btns):
+        btn_list = []
+        for btn_type in ('watch', 'star', 'issues', 'fork', 'follow'):
+            if btns[btn_type] is True:
+                btn_list.append(btn_type)
+        return btn_list
+
     autoapi_python_source = partial(autoapi_source_helper, language='python')
     autoapi_java_source = partial(autoapi_source_helper, language='java')
 
@@ -263,6 +279,10 @@ def get_envdict(yaml_config, default_config):
     config.connect('GITHUB_RIBBON_COLOR', 'build.github_ribbon.color')
     config.connect('GITHUB_RIBBON_POSITION', 'build.github_ribbon.position')
 
+    config.connect('GITHUB_BUTTONS', 'build.github_button.buttons', callback=github_btn_callback)
+    config.connect('GITHUB_BUTTON_LARGE', 'build.github_button.large')
+    config.connect('GITHUB_BUTTON_SHOW_COUNT', 'build.github_button.show_count')
+
     config.connect('SUBPROJECT_URLS', 'build.subproject@url')
     config.connect('SUBPROJECT_DOCPATHS', 'build.subproject@source', default='docs')
 
@@ -279,6 +299,7 @@ def get_envdict(yaml_config, default_config):
     config.connect('JAVADOC_PATH', 'extras.javadoc.path')
 
     yaml_config.connect('GITHUB_RIBBON_ENABLE', 'build.github_ribbon', contains=True)
+    yaml_config.connect('GITHUB_BUTTON_ENABLE', 'build.github_button', contains=True)
 
     envdict = config.getenv()
     envdict.update(yaml_config.getenv())

--- a/modules/scripts/extensions/github_button.py
+++ b/modules/scripts/extensions/github_button.py
@@ -1,0 +1,68 @@
+from docutils import nodes
+
+
+GITHUB_BUTTON_SPEC = {
+    'watch': ('eye', 'https://github.com/{user}/{repo}/subscription'),
+    'star': ('star', 'https://github.com/{user}/{repo}'),
+    'fork': ('repo-forked', 'https://github.com/{user}/{repo}/fork'),
+    'follow': ('', 'https://github.com/{user}'),
+    'issues': ('issue-opened', 'https://github.com/{user}/{repo}/issues'),
+}
+
+
+def get_button_tag(user, repo, btn_type, show_count, size):
+    spec = GITHUB_BUTTON_SPEC[btn_type]
+    icon, href = spec[0], spec[1].format(user=user, repo=repo)
+    tag_fmt = '<a class="github-button" href="{href}" data-size="{size}"'
+    if icon:
+        tag_fmt += ' data-icon="octicon-{icon}"'
+    tag_fmt += ' data-show-count="{show_count}">{text}</a>'
+    return tag_fmt.format(href=href,
+                          icon=icon,
+                          size=size,
+                          show_count=show_count,
+                          text=btn_type.title())
+    
+    
+def get_button_tags(config):
+    btn_types = []
+    if config.github_button_star:
+        btn_types.append('star')
+    if config.github_button_watch:
+        btn_types.append('watch')
+    if config.github_button_fork:
+        btn_types.append('fork')
+    if config.github_button_follow:
+        btn_types.append('follow')
+    if config.github_button_issues:
+        btn_types.append('issues')
+
+    tags = []
+    for btn_type in btn_types:
+        tags.append(get_button_tag(config.github_user_name,
+                                   config.github_repo,
+                                   btn_type,
+                                   config.github_button_show_count,
+                                   config.github_button_size))
+    return '&nbsp;&nbsp;'.join(tags)
+
+
+def on_doctree_resolved(app, doctree, docname):
+    if not app.config.github_user_name or not app.config.github_repo:
+        return
+    buttons = nodes.raw('', get_button_tags(app.config), format='html')
+    doctree.insert(0, buttons)
+
+
+def setup(app):
+    app.connect('doctree-resolved', on_doctree_resolved)
+    app.add_config_value('github_button_star', True, 'html')
+    app.add_config_value('github_button_watch', True, 'html')
+    app.add_config_value('github_button_fork', True, 'html')
+    app.add_config_value('github_button_follow', True, 'html')
+    app.add_config_value('github_button_issues', True, 'html')
+    app.add_config_value('github_user_name', '', 'html')
+    app.add_config_value('github_repo', '', 'html')
+    app.add_config_value('github_button_show_count', 'true', 'html')
+    app.add_config_value('github_button_size', 'large', 'html')
+    app.add_javascript('https://buttons.github.io/buttons.js')

--- a/modules/templates/conf.py_t
+++ b/modules/templates/conf.py_t
@@ -78,11 +78,28 @@ extensions = ['sphinx.ext.githubpages',
 
 {% if github_ribbon_enable == 'true' %}
 extensions.append('sphinxcontrib.github_ribbon')
-{% endif %}
 
 github_ribbon_repo = '{{ owner }}/{{ repo }}'
 github_ribbon_position = '{{ github_ribbon_position }}'
 github_ribbon_color = '{{ github_ribbon_color }}'
+{% endif %}
+
+{% if github_button_enable == 'true' %}
+extensions.append('github_button')
+
+github_user_name = '{{ owner }}'
+github_repo = '{{ repo }}'
+
+gh_btns = '{{ github_buttons }}'.split(',')
+github_button_star = True if 'star' in gh_btns else False
+github_button_watch = True if 'watch' in gh_btns else False
+github_button_issues = True if 'issues' in gh_btns else False
+github_button_fork = True if 'fork' in gh_btns else False
+github_button_follow = True if 'follow' in gh_btns else False
+
+github_button_size = 'large' if '{{ github_button_large }}' == 'true' else 'none'
+github_button_show_count = '{{ github_button_show_count }}'
+{% endif %}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['{{ dot }}templates']


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Option added to display github buttons.
Currently buttons would be shown on every page. This is disabled by default.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #345

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment: https://yaydocx.herokuapp.com

## Screenshots (if appropriate):
![screenshot 201](https://user-images.githubusercontent.com/11555869/28915770-d5cb5108-785d-11e7-8ac3-67634f9d6599.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
