### PR TITLE
Fixes #350 Add support to add disqus comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ extras:
     ui: swagger                                 # Supported UI [ swagger(https://swagger.io/swagger-ui/) ], default: swagger
   javadoc:
     path: 'src/'                                # Path for javadoc source files
+  disqus:
+    short_name: 'yaydoc'                # Unique identifier for a disqus website. To aquire one you need to register a website on https://disqus.com
 ```
 Currently Yaydoc only supports publishing to ghpages and heroku.
 

--- a/generate.sh
+++ b/generate.sh
@@ -111,6 +111,7 @@ sphinx-quickstart -q -v "$VERSION" -a "$AUTHOR" -p "$PROJECTNAME" -t templates/ 
   -d owner=$OWNER -d repo=$REPONAME -d github_ribbon_enable=$GITHUB_RIBBON_ENABLE \
   -d github_ribbon_position=$GITHUB_RIBBON_POSITION -d github_ribbon_color=$GITHUB_RIBBON_COLOR \
   -d theme_opts_keys=$DOCTHEME_OPTIONS_KEYS -d theme_opts_values=$DOCTHEME_OPTIONS_VALUES \
+  -d disqus_shortname=${DISQUS_SHORTNAME} \
   >>${LOGFILE} 2>>${LOGFILE}
 if [ $? -ne 0 ]; then
   print_danger "Failed to initialize build process.\n"
@@ -156,7 +157,7 @@ if [ ! -f index.rst ] && [ ! -f index.md ]; then
   if [ "$DOCPATH" == "." ]; then
     GENINDEX_PARAM=$ROOT_DIR/yaydoctemp
   fi
-  python $BASE/modules/scripts/genindex.py -j "$JAVADOC_PATH" -s "$SUBPROJECT_DIRS" -d "$SUBPROJECT_DOCPATHS" "$GENINDEX_PARAM"
+  python $BASE/modules/scripts/genindex.py -j "$JAVADOC_PATH" -s "$SUBPROJECT_DIRS" -d "$SUBPROJECT_DOCPATHS" -q "${DISQUS_SHORTNAME}" "$GENINDEX_PARAM"
   if [ "${DEBUG:-false}" == "true" ]; then
     print_log "\n--------------------------------------\n"
     cat index.rst | tee -a ${LOGFILE}

--- a/modules/scripts/config.py
+++ b/modules/scripts/config.py
@@ -196,6 +196,7 @@ def get_default_config(owner, repo):
                                    'ui': 'swagger',
                                   },
                        'javadoc': {'path': None,},
+                       'disqus': {'short_name': None},
                       },
            }
     return Configuration(conf)
@@ -277,6 +278,7 @@ def get_envdict(yaml_config, default_config):
     config.connect('SWAGGER_SPEC_URL', 'extras.swagger.url')
     config.connect('SWAGGER_UI', 'extras.swagger.ui')
     config.connect('JAVADOC_PATH', 'extras.javadoc.path')
+    config.connect('DISQUS_SHORTNAME', 'extras.disqus.short_name')
 
     yaml_config.connect('GITHUB_RIBBON_ENABLE', 'build.github_ribbon', contains=True)
 

--- a/modules/scripts/genindex.py
+++ b/modules/scripts/genindex.py
@@ -63,7 +63,7 @@ def _ignore_dirs(dirpath, dirnames, ignored_dirnames, path=None):
                 dirnames.remove(dirname)
 
 
-def get_index(root, subprojects, sub_docpaths, javadoc):
+def get_index(root, subprojects, sub_docpaths, javadoc, disqus):
     index = []
 
     subproject_dirs = [subproject.split(os.path.sep)[0]
@@ -94,8 +94,10 @@ def get_index(root, subprojects, sub_docpaths, javadoc):
                               _title(subproject.split(os.path.sep)[0]))
         index.append(toctree)
     # add javadoc if javadoc exist
-    if javadoc != "":
+    if javadoc:
         index = add_javadoc(index)
+    if disqus:
+        index = add_disqus(index)
 
     return '\n\n'.join(index) + '\n'
 
@@ -104,6 +106,10 @@ def add_javadoc(index):
      "* `javadoc <./javadoc>`_"]
     return index + javadoc
 
+def add_disqus(index):
+    disqus = [".. disqus::"]
+    return index + disqus
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('root', help='Path to the root of the Repository')
@@ -111,11 +117,14 @@ def main():
                         help='Comma seperated subprojects')
     parser.add_argument('-j', '--javadoc', default='',
                         help='Path of java source files for Javadoc')
+    parser.add_argument('-q', '--disqus-shortname', default='',
+                        help='Disqus shortname')
     parser.add_argument('-d', '--sub-docpaths', default='',
                         help='Comma seperated docpaths for subprojects')
     args = parser.parse_args()
     subprojects, sub_docpaths = [], []
     javadoc = args.javadoc
+    disqus = args.disqus_shortname
     if args.subprojects:
         subprojects = [name.strip().replace('/', os.path.sep)
                        for name in args.subprojects.split(',')]
@@ -124,7 +133,7 @@ def main():
                         for name in args.sub_docpaths.split(',')]
     if len(subprojects) != len(sub_docpaths):
         raise ValueError("Invalid arguments")
-    content = get_index(args.root, subprojects, sub_docpaths, javadoc)
+    content = get_index(args.root, subprojects, sub_docpaths, javadoc, disqus)
     with open('index.rst', 'w') as file:
         file.write(content)
 

--- a/modules/templates/conf.py_t
+++ b/modules/templates/conf.py_t
@@ -76,6 +76,13 @@ extensions = ['sphinx.ext.githubpages',
     'timeline',
 ]
 
+{% if disqus_shortname %}
+extensions.append('sphinxcontrib.newsfeed')
+disqus_shortname = '{{ disqus_shortname }}'
+import sphinxcontrib.newsfeed as newsfeed
+newsfeed.DISQUS_TEMPLATE = newsfeed.DISQUS_TEMPLATE.replace('http', 'https')
+{% endif %}
+
 {% if github_ribbon_enable == 'true' %}
 extensions.append('sphinxcontrib.github_ribbon')
 {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mock
 javasphinx
 sphinxcontrib-apiblueprint
 sphinxcontrib-github_ribbon
+sphinxcontrib-newsfeed


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
- Added `disqus` directive to enable disqus comments.
- Updated genindex.py so that if disqus.short_name is provided, adds disqus comments at the bottom of the page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #350 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment: https://yaydocmd.herokuapp.com

## Screenshots (if appropriate):
![screenshot 202](https://user-images.githubusercontent.com/11555869/28972843-e01cb56a-794e-11e7-8acc-8d836dd7db68.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
