### PR TITLE
Fixes #364 Generate headings before toctrees instead of captions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ temp/
 .idea/
 .env
 npm-debug.log
+__pycache__/

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 import unittest
 from mock import patch
 
@@ -41,20 +42,24 @@ class IndexGenerateTestCase(unittest.TestCase):
 
     def test_toctree_directive_nodir(self):
         """Tests the output of get_toctree for files at top level of doc_path"""
-        text = genindex.get_toctree(os.curdir, ['file1.md', 'file2.rst'])
-        self.assertEqual(text, """.. toctree::
+        text = genindex.get_toctree(os.curdir, ['file1.md', 'file2.rst'], 1)
+        self.assertEqual(text, """Contents
+========
+
+.. toctree::
    :maxdepth: 1
-   :caption: Contents
 
    file1
    file2""")
 
     def test_toctree_directive_withdir(self):
         """Tests the output of get_toctree for files under a sub directory"""
-        text = genindex.get_toctree('my_dir', ['file1.md', 'file2.rst'])
-        self.assertEqual(text, """.. toctree::
+        text = genindex.get_toctree('my_dir', ['file1.md', 'file2.rst'], 1)
+        self.assertEqual(text, """My Dir
+======
+
+.. toctree::
    :maxdepth: 1
-   :caption: My Dir
 
    my_dir/file1
    my_dir/file2""")


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
- Each section is now under a specific heading.
- The advantage is that they are also added to the sidebar irrespective of the theme.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #364 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment: https://yaydocx.herokuapp.com/

## Screenshots (if appropriate):
![screenshot 209](https://user-images.githubusercontent.com/11555869/29024233-bb37c4dc-7b8e-11e7-81af-df14b602d87c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
