### PR TITLE
Fixes #374 Delete repository with its log history

### DIFF
--- a/model/buildlog.js
+++ b/model/buildlog.js
@@ -105,3 +105,12 @@ module.exports.storeGithubPagesLogs = function (name, filepath, callback) {
     }
   })
 };
+
+/**
+ * Delete all the logs of a given repository
+ * @param name: `full_name` of the repository
+ * @param callback
+ */
+module.exports.deleteRepositoryLogs = function (name, callback) {
+  BuildLog.deleteMany({repository: name}, callback);
+};

--- a/model/repository.js
+++ b/model/repository.js
@@ -241,3 +241,18 @@ module.exports.getRepositoryWithLatestLogs = function (name, callback) {
     callback(error, results[0]);
   });
 };
+
+/**
+ * Delete a repository with its log history
+ * @param name: `full_name` of the repository
+ * @param callback
+ */
+Repository.deleteRepositoryWithLogs = function (name, callback) {
+  Repository.deleteRepositoryByName(name, function (error, repository) {
+    if (error) {
+      callback(error, repository);
+    } else {
+      BuildLog.deleteRepositoryLogs(name, callback);
+    }
+  });
+};

--- a/routes/repository.js
+++ b/routes/repository.js
@@ -20,7 +20,7 @@ router.post('/delete', function (req, res, next) {
       });
     },
     function (repository, callback) {
-      Repository.deleteRepositoryByName(name, function (error) {
+      Repository.deleteRepositoryWithLogs(name, function (error) {
         callback(error, repository);
       })
     },


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Add model functions to delete buildlogs using repository name
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue #374 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a repository is deleted, we delete its web hook and its document from the database collection. Since we are now storing a log history corresponding to each commit, there is a need to delete them alongwith the repository.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test at https://yaydoc6.herokuapp.com

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
