### PR TITLE
Fixes #390 Change color of callout on build status

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -222,10 +222,16 @@ a {
 .bs-callout-success h4 {
   color: #5cb85c;
 }
+.bs-callout-success h4 a {
+  color: #5cb85c;
+}
 .bs-callout-danger {
   border-left-color: #d9534f;
 }
 .bs-callout-danger h4 {
+  color: #d9534f;
+}
+.bs-callout-danger h4 a {
   color: #d9534f;
 }
 .bs-callout-warning {
@@ -267,4 +273,18 @@ a {
   text-align: center;
   padding: 14px 16px;
   text-decoration: none;
+}
+
+.repolist td {
+  vertical-align: middle
+}
+
+.repolist .reponame {
+  color: #666;
+  text-decoration: none;
+  padding: 5px;
+}
+
+.repolist .reponame:hover {
+  background-color: #f1f1f1;
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -138,6 +138,7 @@ router.get('/:owner/:reponame/logs/:buildNumber', function (req, res, next) {
       repository: result,
       hostname: hostname,
       specificLog: true,
+      loggedIn: !!req.user,
     });
   });
 });

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -65,12 +65,13 @@ block content
       ul(style="list-style:none")
         li
           h4(style="font-weight: 700") #{user.name}
-          table.table
+          table.table.repolist
             if ownedRepositories && ownedRepositories.length !== 0
               each repository in ownedRepositories
                 tr
-                  td #{repository.name}
-                  td(style="width:0;vertical-align: middle")
+                  td
+                    a.reponame(href="/#{repository.name}") #{repository.name}
+                  td(style="width:0")
                     a(href="/#{repository.name}/settings")
                       i.fa.fa-gear.fa-2x
                   td(style="width:0")
@@ -88,12 +89,13 @@ block content
           each organization in organizations
             li
               h4(style="font-weight: 700") #{organization.name}
-              table.table
+              table.table.repolist
                 if organization.repositories && organization.repositories.length !== 0
                   each repository in organization.repositories
                     tr
-                      td(style="vertical-align: middle") #{repository.name}
-                      td(style="width:0;vertical-align: middle")
+                      td
+                        a.reponame(href="/#{repository.name}") #{repository.name}
+                      td(style="width:0")
                         a(href="/#{repository.name}/settings")
                           i.fa.fa-gear.fa-2x
                       td(style="width:0")

--- a/views/repository/index.jade
+++ b/views/repository/index.jade
@@ -22,7 +22,7 @@ block content
       if specificLog
         li.active
           a(href="#") Build ##{buildLog.buildNumber}
-    .bs-callout.bs-callout-info
+    .bs-callout(class="#{buildLog.metadata.status ? 'bs-callout-success' : 'bs-callout-danger'} ")
       .row
         .col-md-6
           h4
@@ -42,10 +42,14 @@ block content
           ul(style="list-style:none")
             li Status: #{status}
             li
-              strong #{buildLog.metadata.headCommit.author.name}
-              | &nbsp;authored and&nbsp;
-              strong #{buildLog.metadata.headCommit.committer.name}
-              | &nbsp;committed
+              if buildLog.metadata.headCommit.author.name === buildLog.metadata.headCommit.committer.name
+                strong #{buildLog.metadata.headCommit.author.name}
+                | &nbsp;authored and committed
+              else
+                strong #{buildLog.metadata.headCommit.author.name}
+                | &nbsp;authored and&nbsp;
+                strong #{buildLog.metadata.headCommit.committer.name}
+                | &nbsp;committed
     .panel-group#accordion
       .panel.panel-default
         .panel-heading

--- a/views/repository/logs.jade
+++ b/views/repository/logs.jade
@@ -16,7 +16,7 @@ block content
     for buildLog in buildLogs
       - buildLog = buildLog.logs
       - status = buildLog.metadata.status ? 'Success' : 'Failed'
-      .bs-callout.bs-callout-info
+      .bs-callout(class="#{buildLog.metadata.status ? 'bs-callout-success' : 'bs-callout-danger'} ")
         .row
           .col-md-6
             h4
@@ -37,10 +37,14 @@ block content
             ul(style="list-style:none")
               li Status: #{status}
               li
-                strong #{buildLog.metadata.headCommit.author.name}
-                | &nbsp;authored and&nbsp;
-                strong #{buildLog.metadata.headCommit.committer.name}
-                | &nbsp;committed
+                if buildLog.metadata.headCommit.author.name === buildLog.metadata.headCommit.committer.name
+                  strong #{buildLog.metadata.headCommit.author.name}
+                  | &nbsp;authored and committed
+                else
+                  strong #{buildLog.metadata.headCommit.author.name}
+                  | &nbsp;authored and&nbsp;
+                  strong #{buildLog.metadata.headCommit.committer.name}
+                  | &nbsp;committed
   .modal.fade#statustag-modal(role='dialog')
     .modal-dialog
       .modal-content


### PR DESCRIPTION

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue #390 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Looking at the logs, a user cannot find if the build was successful or not. In order to determine the status, user will have to search for it in the logs. Such a UX is not desired. Change the colour of callout and also show status with the metadata in order to improve user experience.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test at https://yaydoc6.herokuapp.com
## Screenshots (if appropriate):
https://yaydoc6.herokuapp.com/imujjwal96/mydoc/logs
![image](https://user-images.githubusercontent.com/8245662/29407517-47876b42-8362-11e7-9e43-9e664e0196d6.png)
https://yaydoc6.herokuapp.com/imujjwal96/mydoc/logs/2
![image](https://user-images.githubusercontent.com/8245662/29407590-7f174abe-8362-11e7-996e-cba0da8fb4f1.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
