### PR TITLE
Fixes #387 Add openjdk8 in Dockerfile for javadocs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM node:boron
 
+RUN echo deb http://http.debian.net/debian jessie-backports main >> /etc/apt/sources.list
+
 # Update and install packages
 RUN apt-get update && \
-    apt-get install -y python python-dev python-pip python-virtualenv zip rsync && rm -rf /var/lib/apt/lists/*
+    apt-get install -y -t jessie-backports python python-dev python-pip python-virtualenv zip rsync openjdk-8-jdk && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+ENV PATH="$JAVA_HOME/bin:$PATH"
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
issue #387 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Generating documentation for projects containing javadocs failed due to the absence of java environment
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
