### PR TITLE
Fixes #397 Add option to disable inline math

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ metadata:
   projectname: Yaydoc    # Name of the Project, default: Name of the repository
   version: development   # Version of the Project, default: UTC date of latest deployment
   debug: true            # Enables detailed logging, default: false
+  inline_math: true      # Enable inline math. This only affects markdown documents, default: false
   autoindex:             # Control various properties of the auto-generated index which is used to generate the landing page of the generated docs
     include:             # Names of Documents which should be included at the top of the index. Files specified here if present, would be used to generate the starting page of the generated docs. default: README.md, README.rst
       - README.md

--- a/generate.sh
+++ b/generate.sh
@@ -144,6 +144,7 @@ sphinx-quickstart -q -v "$VERSION" -a "$AUTHOR" -p "$PROJECTNAME" -t templates/ 
   -d theme_opts_keys=${DOCTHEME_OPTIONS_KEYS} -d theme_opts_values=${DOCTHEME_OPTIONS_VALUES} \
   -d github_button_enable=${GITHUB_BUTTON_ENABLE} -d github_buttons=${GITHUB_BUTTONS} \
   -d github_button_large=${GITHUB_BUTTON_LARGE} -d github_button_show_count=${GITHUB_BUTTON_SHOW_COUNT} \
+  -d enable_inline_math=${ENABLE_INLINE_MATH} \
   >>${LOGFILE} 2>>${LOGFILE}
 
 if [ $? -ne 0 ]; then

--- a/modules/scripts/config/__main__.py
+++ b/modules/scripts/config/__main__.py
@@ -23,6 +23,7 @@ def get_default_config(owner, repo):
                          'version': utctime,
                          'author': owner,
                          'debug': False,
+                         'inline_math': False,
                          'autoindex': {'include': ['README.md', 'README.rst'],
                                        'subproject': {'show': True,
                                                       'heading': 'Sub Projects',
@@ -89,6 +90,7 @@ def get_envdict(yaml_config, default_config):
     config.connect('VERSION', 'metadata.version')
     config.connect('AUTHOR', 'metadata.author')
     config.connect('DEBUG', 'metadata.debug')
+    config.connect('ENABLE_INLINE_MATH', 'metadata.inline_math')
     config.connect('AUTOINDEX_INCLUDE_FILES', 'metadata.autoindex.include@')
     config.connect('AUTOINDEX_INCLUDE_TOC', 'metadata.autoindex.toc.show')
     config.connect('AUTOINDEX_TOC_HEADING', 'metadata.autoindex.toc.heading')

--- a/modules/templates/conf.py_t
+++ b/modules/templates/conf.py_t
@@ -318,5 +318,6 @@ def setup(app):
         'enable_eval_rst': True,
         'enable_auto_toc_tree': True,
         'auto_toc_tree_section': 'Contents',
+        'enable_inline_math': deserialize('{{ enable_inline_math }}'),
     }, True)
     app.add_transform(AutoStructify)


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
Added new option to disable inline_math.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #397 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this recommonmark tries to parse inline math even when not intended resulting in parse error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment: https://yaydocw.herokuapp.com

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [x] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
