### PR TITLE
Fixes #413 Ignore files and directories starting with dot

### DIFF
--- a/modules/scripts/genindex.py
+++ b/modules/scripts/genindex.py
@@ -38,8 +38,9 @@ def get_toctree(dirpath, filenames, level, caption=''):
         path, ext = os.path.splitext(os.path.join(dirpath, filename))
         if ext not in ('.md', '.rst'):
             continue
-        document = path.replace(os.path.sep, '/')
-        document = document.lstrip('./').rstrip('/')
+        document = path.replace(os.path.sep, '/').rstrip('/')
+        if document.startswith('./'):
+            document = document[2:]
         toctree.append(content_template.format(document=document))
         valid = True
 
@@ -98,7 +99,9 @@ def get_index(root, subprojects, sub_docpaths, javadoc):
         # Add toctrees as per the directory structure
         for (dirpath, dirnames, filenames) in os.walk(os.curdir):
             _ignore_files(dirpath, filenames, included_files, root)
-            _ignore_dirs(dirpath, dirnames, ['yaydoctemp', 'yaydocclone', '.git'])
+            _ignore_files(dirpath, filenames, filter(lambda x: x.startswith('.'), filenames))
+            _ignore_dirs(dirpath, dirnames, filter(lambda x: x.startswith('.'), dirnames))
+            _ignore_dirs(dirpath, dirnames, ['yaydoctemp', 'yaydocclone'])
             _ignore_dirs(dirpath, dirnames, ['source'] + subproject_dirs, os.curdir)
 
             if filenames:


### PR DESCRIPTION
<!--
Thanks for submitting a change to yaydoc!

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

-->

## Description
<!--- Describe your changes in detail -->
- Ignored directory and files starting with a `"."`
- Fixed a bug related to normalizing path to a detected directory.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #413 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Otherwise, if docpath is `"."` and the repo contains files like `PULL_REQUEST_TEMPLATE` inside `.github` directory, they are also added to the auto generated index.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployment: https://yaydocw.herokuapp.com/

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix 
- [ ] New feature

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [Contribution & Best practices Guide](https://blog.fossasia.org/open-source-developer-guide-and-best-practices-at-fossasia) and my PR follows them.
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`
- [x] There is only one commit per issue.
